### PR TITLE
add benchmarks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,15 @@ module github.com/starboard-nz/lockunique
 go 1.19
 
 require (
+	github.com/rs/zerolog v1.29.0
+	github.com/stretchr/testify v1.8.1
+)
+
+require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/rs/zerolog v1.29.0 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
 	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYeFQAuuMYFkjaqXzl5Wo=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
I wanted to explore this repo a bit by writing a benchmark test. 

IS the `Benchmark1point6mill/1.6_million_locks_unlocks_(map_version)-16` implementation representative of the current way we do locking? it looks like it is a bit faster in the naive test of making a map of locks with 1.6 million entries.
```
goos: linux
goarch: amd64
pkg: github.com/starboard-nz/lockunique
cpu: 12th Gen Intel(R) Core(TM) i7-1260P
Benchmark1point6mill/1.6_million_locks-16         	
1000000000	         0.6862 ns/op
Benchmark1point6mill/1.6_million_locks_unlocks_(map_version)-16         	1000000000	         0.3093 ns/op
PASS
ok  	github.com/starboard-nz/lockunique	44.513s
```
